### PR TITLE
Remove --system argument from adduser

### DIFF
--- a/init
+++ b/init
@@ -59,7 +59,14 @@ fi
 # Create user/group
 addgroup --quiet --gid "$YOUTUBEDLPGID" dockeruser
 chown -R "$YOUTUBEDLPUID":"$YOUTUBEDLPGID" /home/dockeruser
-adduser --quiet --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --home /home/dockeruser dockeruser
+if [[ "$YOUTUBEDLPUID" -gt "1000" ]]; then
+    adduser --quiet --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --home /home/dockeruser dockeruser
+elif [[ "$YOUTUBEDLPUID" -gt "100" ]]; then
+    adduser --quiet --system --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --home /home/dockeruser dockeruser
+else 
+    echo "PUID must be greater than 100."
+    exit 1
+fi
 chown -R "$YOUTUBEDLPUID":"$YOUTUBEDLPGID" /usr/local/bin/yt-dlp
 chmod u+s /usr/local/bin/yt-dlp
 HOME=/home/dockeruser

--- a/init
+++ b/init
@@ -59,11 +59,11 @@ fi
 # Create user/group
 addgroup --quiet --gid "$YOUTUBEDLPGID" dockeruser
 chown -R "$YOUTUBEDLPUID":"$YOUTUBEDLPGID" /home/dockeruser
-if [[ "$YOUTUBEDLPUID" -gt "1000" ]]; then
-    adduser --quiet --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --home /home/dockeruser dockeruser
+if [[ "$YOUTUBEDLPUID" -gt "999" ]]; then
+    adduser --quiet --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --gecos "" --home /home/dockeruser dockeruser
 elif [[ "$YOUTUBEDLPUID" -gt "100" ]]; then
-    adduser --quiet --system --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --home /home/dockeruser dockeruser
-else 
+    adduser --quiet --system --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --gecos "" --home /home/dockeruser dockeruser
+else
     echo "PUID must be greater than 100."
     exit 1
 fi

--- a/init
+++ b/init
@@ -59,7 +59,7 @@ fi
 # Create user/group
 addgroup --quiet --gid "$YOUTUBEDLPGID" dockeruser
 chown -R "$YOUTUBEDLPUID":"$YOUTUBEDLPGID" /home/dockeruser
-adduser --quiet --system --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --home /home/dockeruser dockeruser
+adduser --quiet --disabled-password --uid "$YOUTUBEDLPUID" --gid "$YOUTUBEDLPGID" --home /home/dockeruser dockeruser
 chown -R "$YOUTUBEDLPUID":"$YOUTUBEDLPGID" /usr/local/bin/yt-dlp
 chmod u+s /usr/local/bin/yt-dlp
 HOME=/home/dockeruser


### PR DESCRIPTION
# Problem

The default Debian image is configured to allow system users to exist in the 100-999 `UID` range.
If you don't specify a `UID` value the default is 1000, which falls outside the allowed system range.

Additionally, the use of `adduser` without specifying a `--gecos` argument requires the user to interact with the container at runtime.

# Solution
By detecting the UID value before using it, we can either create a system or non system user as needed to avoid the issue.

Additionally, provide a default blank `--gecos` value to allow for unattended use.


